### PR TITLE
env: release.yamlを追加

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,20 @@
+changelog:
+  categories:
+    - title: "✨ Feature"
+      labels:
+        - "✨ Feature"
+    - title: "🐛 Bug"
+      labels:
+        - "🐛 Bug"
+    - title: ":recycle: Refactoring"
+      labels:
+        - ":recycle: Refactoring"
+    - title: ":gear: Environment"
+      labels:
+        - ":gear: Environment"
+    - title: ":robot: Dependencies"
+      labels:
+        - ":robot: Dependencies"
+    - title: "📝 Documentation"
+      labels:
+        - "📝 Documentation"


### PR DESCRIPTION
# 概要
release.yamlを追加
https://docs.github.com/ja/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes