### PR TITLE
fix: matchesの条件修正

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,10 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://*.atlassian.net/*"],
+      "matches": [
+        "https://*.atlassian.net/jira/*",
+        "https://*.atlassian.net/browse/*"
+      ],
       "js": ["src/content_script/main.ts"],
       "run_at": "document_start"
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,7 @@
         "https://*.atlassian.net/browse/*"
       ],
       "js": ["src/content_script/main.ts"],
-      "run_at": "document_start"
+      "run_at": "document_end"
     }
   ]
 }


### PR DESCRIPTION
# 概要
matchesの条件修正。

`https://*.atlassian.net/*`だと、
Jira Software以外の、コンフルエンス等のサービスも対象となってしまっていたため、条件を絞りました。

また、run_atの指定もdocument_endに変更。